### PR TITLE
userモデルとのアソシエーションの設定

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :brand
   has_many   :images
+  belongs_to :user
 
   validates :name, presence: true, length: { maximum: 40 }
   validates :description, presence: true, length: { maximum: 1000 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
 
+  has_many :items, dependent: :destroy
   has_one :sns_credential, dependent: :destroy
 
   validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :phone_number, :birth_year, :birth_month, :birth_day, presence: true

--- a/db/migrate/20191104110940_add_sellerid_to_item.rb
+++ b/db/migrate/20191104110940_add_sellerid_to_item.rb
@@ -1,0 +1,5 @@
+class AddSelleridToItem < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :items, :seller, null: false, foreign_key: {to_table: :users}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_04_094012) do
+ActiveRecord::Schema.define(version: 2019_11_04_110940) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,8 +48,10 @@ ActiveRecord::Schema.define(version: 2019_11_04_094012) do
     t.datetime "updated_at", null: false
     t.bigint "category_id", null: false
     t.bigint "brand_id", null: false
+    t.bigint "seller_id", null: false
     t.index ["brand_id"], name: "index_items_on_brand_id"
     t.index ["category_id"], name: "index_items_on_category_id"
+    t.index ["seller_id"], name: "index_items_on_seller_id"
   end
 
   create_table "sns_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -87,5 +89,6 @@ ActiveRecord::Schema.define(version: 2019_11_04_094012) do
   add_foreign_key "images", "items"
   add_foreign_key "items", "brands"
   add_foreign_key "items", "categories"
+  add_foreign_key "items", "users", column: "seller_id"
   add_foreign_key "sns_credentials", "users"
 end


### PR DESCRIPTION
# What
Itemモデルとuserモデルとのアソシエーションを設定する。
出品者の情報を登録するためカラム名は「seller_id」とする

# Why
商品情報と出品者情報を紐付けるため