### PR TITLE
[WIP] 新規登録遷移(pay.jp)

### DIFF
--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -13,7 +13,7 @@ class CardController < ApplicationController
   def create
     Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
     if params['payjp_token'].blank?
-      redirect_to action: "new", id: current_user.id
+      redirect_to action: "new", id: current_user.id and return
     else
       customer = Payjp::Customer.create(
       card: params['payjp_token'],
@@ -21,9 +21,15 @@ class CardController < ApplicationController
       ) 
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       if @card.save
-        redirect_to action: "show"
+        path = Rails.application.routes.recognize_path(request.referer)
+        if path[:controller] == "card" && path[:action] == "new" 
+          redirect_to action: "show" and return
+        else
+          redirect_to done_signup_index_path and return
+        end
+        redirect_to action: "show" and return
       else
-        redirect_to action: "create"
+        redirect_to action: "create" and return
       end
     end
   end
@@ -52,11 +58,11 @@ class CardController < ApplicationController
   end
 
   private
-def set_card
-  @card = current_user.cards
-end
+  def set_card
+    @card = current_user.cards
+  end
 
-def set_card_first
-  @card = current_user.cards.first
-end
+  def set_card_first
+    @card = current_user.cards.first
+  end
 end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,6 +1,5 @@
 class SignupController < ApplicationController
 
-
   def new
     @user = User.new 
   end
@@ -43,23 +42,23 @@ class SignupController < ApplicationController
     # session[:street_name_house_attributes]          = user_params[:street_name]
     # session[:apt_house_attributes]                  = user_params[:apt]
     # session[:phone_number_house_attributes]         = user_params[:phone_number]
-    session[:house_attributes] = user_params[:house_attributes]
-    @user = User.new
-    @user.build_house
+    # session[:house_attributes] = user_params[:house_attributes]
+    # @user = User.new
+    # @user.build_house
   end
 
 
   def done
-    # step4で入力された値をsessionに保存
     sign_in User.find(session[:user_id]) unless user_signed_in?
 
   end
 
 
   def create
-    # ＃ここに全部ぶっこむ
-    #step4の文もdoneではなくここに入れる
-    #..: user_params[:..]
+    session[:house_attributes] = user_params[:house_attributes]
+    @user = User.new
+    @user.build_house
+    
     @user = User.new(
       nickname:                   session[:nickname],
       email:                      session[:email],
@@ -82,9 +81,9 @@ class SignupController < ApplicationController
     #ここでidをsessionに入れることでログイン状態に持っていける。
     #ログイン状態維持のためuser_idをsessionに保存
     session[:user_id] = @user.id
-    redirect_to done_signup_index_path
+    redirect_to step4_signup_index_path
     else
-    render step4_signup_index_path
+    render step3_signup_index_path
     end
   end
 
@@ -104,8 +103,8 @@ class SignupController < ApplicationController
         :first_name_kana,
         :birth_year,
         :birth_month,
-        :birth_day,  #step1
-        :phone_number,     #step2
+        :birth_day,  
+        :phone_number,     
         house_attributes:[
           :id,
           :first_name,
@@ -117,7 +116,7 @@ class SignupController < ApplicationController
           :city,
           :street_name,
           :apt,
-          :phone_number  #step3
+          :phone_number 
         ]
     )
     end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -85,6 +85,8 @@ class SignupController < ApplicationController
     else
     render step3_signup_index_path
     end
+    sign_in User.find(session[:user_id]) unless user_signed_in?
+
   end
 
 

--- a/app/views/signup/done.html.haml
+++ b/app/views/signup/done.html.haml
@@ -27,12 +27,8 @@
         .registration-form__content
           %p.complete.message ありがとうございます。
           %p.complete.message 会員登録が完了しました。
-          -# %button.btn-default.btn-red{type: "submit"} メルカリをはじめる
-          -# =link_to root_path(current_user) 
           .btn-default.btn-red
-            = link_to 'メルカリをはじめる', root_path(current_user)
-            -#  it was impossible for me to understand how to do this shit. If somebody has the knowledge, your free to take care of this shit.
-
+            = link_to 'メルカリをはじめる', current_user, :style=>"color:white;"
       %image
         = image_tag "banner-pc.jpg", class:"image__sub-footer"
     = render "devise/shared/login_footer"

--- a/app/views/signup/step3.html.haml
+++ b/app/views/signup/step3.html.haml
@@ -23,7 +23,8 @@
   %main.single-main
     %section.single-main__container
       %h2.single-main__container__header 住所入力
-      = form_for @user,url: step4_signup_index_path,method: :get, html: {class:"registration-form"} do |f|
+
+      = form_for @user,url: signup_index_path,method: :post, html: {class:"registration-form"} do |f|
         = f.fields_for :house do |f|
           .registration-form__content
             .form-group

--- a/app/views/signup/step4.html.haml
+++ b/app/views/signup/step4.html.haml
@@ -24,13 +24,16 @@
     .content-signin
       .content-signin__chapter1
         %h2.content-signin__chapter1__top 支払い方法
-        = form_tag(signup_index_path , method: :post,class: "card-form") do
+        -# = form_tag(signup_index_path , method: :post,class: "card-form") do
+        = form_tag(card_index_path, method: :post, id: 'charge-form', class:'card-form', name: "inputForm") do
           .card-form__input
           .card-form__box
             .form-number
               %label.form-number__payment カード番号
               %span.form-number__require 必須
-              %input.form-number__input{type:"text",placeholder:"半角数字のみ",maxlength:"19"}
+              = text_field_tag "number", "", class: "form-number__input", placeholder: "半角数字のみ" ,maxlength: "16", type: "text", id: "card_number"
+              -# %input.form-number__input{type:"text",placeholder:"半角数字のみ",maxlength:"19"}
+              %br
               %ul.form-number__error-text
               %ul.form-number__card-list
                 %li.form-number__card-list__visa
@@ -52,7 +55,7 @@
               %span.form-signup__require 必須
               %br
               .form-signup__month
-                %select.form-signup__month__select
+                %select.form-signup__month__select#exp_month{name: "exp_month", type: "text"}
                   %option{value:"1"} 01
                   %option{value:"2"} 02
                   %option{value:"3"} 03
@@ -69,7 +72,7 @@
               %span.form-signup__str 月
               %br
               .form-signup__year
-                %select.form-signup__month__select
+                %select.form-signup__month__select#exp_year{name: "exp_year", type: "text"}
                   %option{value:"19"} 19
                   %option{value:"20"} 20
                   %option{value:"21"} 21
@@ -86,14 +89,18 @@
             .form-security
               %label.form-security__expire セキュリティコード
               %span.form-security__require 必須
-              %input.form-security__input{placeholder:"カード背面４桁もしくは３桁の番号"}
+              = text_field_tag "cvc", "", class: "form-security__input", placeholder: "カード背面4桁もしくは3桁の番号", maxlength: "4", id: "cvc"
+              -# %input.form-security__input{placeholder:"カード背面４桁もしくは３桁の番号"}
               %ul.form-security__error-message
               .form-security__info 
-                %span.form-security__info__question ?
+                %span.form-security__info__question 
                 カード裏面の番号とは？
-            %input.user_id{type:"hidden"}
-            %input.encrypted_card_data{type:"hidden"}
-            %p.has-error-text
-            %input{type:"hidden",value_name:"after_save_callback"}
-            %button.btn-default.btn-red{type: "submit"} 次へ進む   
+            -# %input.user_id{type:"hidden"}
+            -# %input.encrypted_card_data{type:"hidden"}
+            -# %p.has-error-text
+            -# %input{type:"hidden",value_name:"after_save_callback"}
+            -# %button.btn-default.btn-red{type: "submit"} 次へ進む   
+            .btn-default
+              #card_token
+              = submit_tag "次へ進む", id: "token_submit", class: "form-btn"                
     = render "devise/shared/login_footer"

--- a/app/views/signup/step4.html.haml
+++ b/app/views/signup/step4.html.haml
@@ -24,7 +24,6 @@
     .content-signin
       .content-signin__chapter1
         %h2.content-signin__chapter1__top 支払い方法
-        -# = form_tag(signup_index_path , method: :post,class: "card-form") do
         = form_tag(card_index_path, method: :post, id: 'charge-form', class:'card-form', name: "inputForm") do
           .card-form__input
           .card-form__box
@@ -32,7 +31,6 @@
               %label.form-number__payment カード番号
               %span.form-number__require 必須
               = text_field_tag "number", "", class: "form-number__input", placeholder: "半角数字のみ" ,maxlength: "16", type: "text", id: "card_number"
-              -# %input.form-number__input{type:"text",placeholder:"半角数字のみ",maxlength:"19"}
               %br
               %ul.form-number__error-text
               %ul.form-number__card-list
@@ -56,51 +54,47 @@
               %br
               .form-signup__month
                 %select.form-signup__month__select#exp_month{name: "exp_month", type: "text"}
-                  %option{value:"1"} 01
-                  %option{value:"2"} 02
-                  %option{value:"3"} 03
-                  %option{value:"4"} 04
-                  %option{value:"5"} 05
-                  %option{value:"6"} 06
-                  %option{value:"7"} 07
-                  %option{value:"8"} 08
-                  %option{value:"9"} 09
-                  %option{value:"10"} 10
-                  %option{value:"11"} 11
-                  %option{value:"12"} 12
+                  %option{value: ""} --
+                  %option{value: "1"}01
+                  %option{value: "2"}02
+                  %option{value: "3"}03
+                  %option{value: "4"}04
+                  %option{value: "5"}05
+                  %option{value: "6"}06
+                  %option{value: "7"}07
+                  %option{value: "8"}08
+                  %option{value: "9"}09
+                  %option{value: "10"}10
+                  %option{value: "11"}11
+                  %option{value: "12"}12
                 %i.form-signup__month__icon.fas.fa-chevron-down
               %span.form-signup__str 月
               %br
               .form-signup__year
                 %select.form-signup__month__select#exp_year{name: "exp_year", type: "text"}
-                  %option{value:"19"} 19
-                  %option{value:"20"} 20
-                  %option{value:"21"} 21
-                  %option{value:"22"} 22
-                  %option{value:"23"} 23
-                  %option{value:"24"} 24
-                  %option{value:"25"} 25
-                  %option{value:"26"} 26
-                  %option{value:"27"} 27
-                  %option{value:"28"} 28
-                  %option{value:"29"} 29
+                  %option{value: ""} --
+                  %option{value: "2019"}19
+                  %option{value: "2020"}20
+                  %option{value: "2021"}21
+                  %option{value: "2022"}22
+                  %option{value: "2023"}23
+                  %option{value: "2024"}24
+                  %option{value: "2025"}25
+                  %option{value: "2026"}26
+                  %option{value: "2027"}27
+                  %option{value: "2028"}28
+                  %option{value: "2029"}29
                 %i.form-signup__month__icon.fas.fa-chevron-down
               %span.form-signup__str 年
             .form-security
-              %label.form-security__expire セキュリティコード
+              %label.form-security__expire セキュリティーコード
               %span.form-security__require 必須
               = text_field_tag "cvc", "", class: "form-security__input", placeholder: "カード背面4桁もしくは3桁の番号", maxlength: "4", id: "cvc"
-              -# %input.form-security__input{placeholder:"カード背面４桁もしくは３桁の番号"}
               %ul.form-security__error-message
-              .form-security__info 
-                %span.form-security__info__question 
+              .form-security__info
+                %span.form-security__info__question
                 カード裏面の番号とは？
-            -# %input.user_id{type:"hidden"}
-            -# %input.encrypted_card_data{type:"hidden"}
-            -# %p.has-error-text
-            -# %input{type:"hidden",value_name:"after_save_callback"}
-            -# %button.btn-default.btn-red{type: "submit"} 次へ進む   
             .btn-default
               #card_token
-              = submit_tag "次へ進む", id: "token_submit", class: "form-btn"                
+              = submit_tag "次へ進む", id: "token_submit", class: "form-btn" 
     = render "devise/shared/login_footer"


### PR DESCRIPTION
# What 
新規登録時にクレジットカードの情報をcard及びuserに登録する。
その他のsessionも邪魔しない
登録後、confirimationでは既に登録済み状態にする
# Why 
新規登録におけるクレジットカード登録を実現する。